### PR TITLE
build 0.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,8 @@ test:
     - captum._utils
   commands:
     - pip check
-    - pytest upstream/tests
+    - pytest upstream/tests  # [not win]
+    - pytest upstream/tests --ignore="upstream/tests/attr/test_data_parallel.py"  # [win]
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python
     - matplotlib-base
-    - numpy {{ numpy }}
+    - numpy
     - pytorch >=1.6
     # seems to be optional since upstream says "It will try to use tqdm if available"
     # but it is also imported in production code

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "captum" %}
-{% set version = "0.5.0" %}
+{% set version = "0.7.0" %}
 
 
 package:
@@ -8,22 +8,26 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/captum-{{ version }}.tar.gz
-  sha256: 84af2c8793d34c440a351793b5ca705b8542745e2dc8bc24afb1d9b86f3bf6ec
+  sha256: 7ca87d0dc67b3b7589a730b970b9536172a5468e0e31bf8657fdd73abc568a33
 
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
   run:
-    - python >=3.6
+    - python
     - matplotlib-base
-    - numpy
+    - numpy {{ numpy }}
     - pytorch >=1.6
+    # seems to be optional since upstream says "It will try to use tqdm if available"
+    # but it is also imported in production code
+    - tqdm
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,11 +42,12 @@ test:
     - captum._utils
   commands:
     - pip check
-    - pytest upstream/tests  # [not win and not (osx and x86 and py==312)]
+    - pytest upstream/tests  # [not win and not (osx and x86)]
     # Bypass dependency conflict for scikit-learn on osx-64 with python 3.12.
-    - pytest upstream/tests -k "not test_llm_attr_without_token"  # [osx and x86 and py==312]
-    # Test collection error on Windows.
-    - pytest upstream/tests --ignore="upstream/tests/attr/test_data_parallel.py"  # [win]
+    - pytest upstream/tests -k "not test_llm_attr_without_token" --ignore="upstream/tests/attr/test_data_parallel.py" # [osx and x86 and py==312]
+    # Test collection error on Windows and osx-64
+    - pytest upstream/tests --ignore="upstream/tests/attr/test_data_parallel.py"  # [win or (osx and x86 and py<312)]
+
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,9 @@ test:
   commands:
     - pip check
     - pytest upstream/tests  # [not win and not (osx and x86 and py==312)]
-    - pytest upstream/tests -k "not (TestLLMAttr_0_cpu.test_llm_attr_without_token_0 or TestLLMAttr_0_cpu.test_llm_attr_without_token_1)"  # [osx and x86 and py==312]
+    # Bypass dependency conflict for scikit-learn on osx-64 with python 3.12.
+    - pytest upstream/tests -k "not test_llm_attr_without_token_0"  # [osx and x86 and py==312]
+    # Test collection error on Windows.
     - pytest upstream/tests --ignore="upstream/tests/attr/test_data_parallel.py"  # [win]
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,14 +42,15 @@ test:
     - captum._utils
   commands:
     - pip check
-    - pytest upstream/tests  # [not win]
+    - pytest upstream/tests  # [not win and not (osx and x86 and py==312)]
+    - pytest upstream/tests -k "not (TestLLMAttr_0_cpu.test_llm_attr_without_token_0 or TestLLMAttr_0_cpu.test_llm_attr_without_token_1)"  # [osx and x86 and py==312]
     - pytest upstream/tests --ignore="upstream/tests/attr/test_data_parallel.py"  # [win]
   requires:
     - pip
     - pytest
     - sphinx
     - mypy >=0.760
-    - scikit-learn
+    - scikit-learn  # [not (osx and x86 and py==312)]
     - parameterized
     - flask
     - flask-compress

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - pip
     - python
     - setuptools
+    - wheel
   run:
     - python
     - matplotlib-base
@@ -59,6 +60,7 @@ about:
   dev_url: https://github.com/pytorch/captum
   license: BSD-3-Clause
   license_file: LICENSE
+  license_family: BSD
   description: |
     Captum is a model interpretability and understanding library for PyTorch.
     Captum means comprehension in Latin and contains general purpose

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ test:
     - pip check
     - pytest upstream/tests  # [not win and not (osx and x86 and py==312)]
     # Bypass dependency conflict for scikit-learn on osx-64 with python 3.12.
-    - pytest upstream/tests -k "not test_llm_attr_without_token_0"  # [osx and x86 and py==312]
+    - pytest upstream/tests -k "not test_llm_attr_without_token"  # [osx and x86 and py==312]
     # Test collection error on Windows.
     - pytest upstream/tests --ignore="upstream/tests/attr/test_data_parallel.py"  # [win]
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/captum-{{ version }}.tar.gz
-  sha256: 7ca87d0dc67b3b7589a730b970b9536172a5468e0e31bf8657fdd73abc568a33
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/captum-{{ version }}.tar.gz
+    sha256: 7ca87d0dc67b3b7589a730b970b9536172a5468e0e31bf8657fdd73abc568a33
+  - git_url: https://github.com/pytorch/captum
+    git_rev: v0.7.0
+    folder: upstream
 
 build:
   number: 0
@@ -16,6 +19,8 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - git  # [not win]
   host:
     - pip
     - python
@@ -30,13 +35,23 @@ requirements:
     - tqdm
 
 test:
+  source_files:
+    - upstream/tests
   imports:
     - captum
     - captum._utils
   commands:
     - pip check
+    - pytest upstream/tests
   requires:
     - pip
+    - pytest
+    - sphinx
+    - mypy >=0.760
+    - scikit-learn
+    - parameterized
+    - flask
+    - flask-compress
 
 about:
   home: https://captum.ai


### PR DESCRIPTION
captum 0.7.0

**Destination channel:** Defaults

### Links

- [PKG-4659]
- [Upstream repository](https://github.com/pytorch/captum/tree/v0.7.0)

### Explanation of changes:

- Issues with tests that popped up:
  - `scikit-learn` conflicts on osx-64 with python 3.12. I skipped the related tests and removed the `scikit-learn` pinning.
  - Windows and osx-64 both had issues with collecting tests from `attr/test_data_parallel.py` as it requires the unsupported `torch.distributed` module.

[PKG-4659]: https://anaconda.atlassian.net/browse/PKG-4659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ